### PR TITLE
Update git rev

### DIFF
--- a/dev.bambosh.UnofficialHomestuckCollection.yml
+++ b/dev.bambosh.UnofficialHomestuckCollection.yml
@@ -1,9 +1,9 @@
 app-id: dev.bambosh.UnofficialHomestuckCollection
 runtime: org.freedesktop.Platform
-runtime-version: "22.08"
+runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: "22.08"
+base-version: "23.08"
 command: unofficial-homestuck-collection
 separate-locales: false
 finish-args:
@@ -37,8 +37,8 @@ modules:
         sha256: e60bc6710cf4e0852fc375d33699d0dcdf69707ff942753f31742fabb2a867d0
       # Required for icons, desktop file and appstream file
       - type: git
-        url: https://github.com/Bambosh/unofficial-homestuck-collection.git
-        commit: 3f44ba5
+        url: https://github.com/GiovanH/unofficial-homestuck-collection.git
+        commit: c981b0b
       # Wrapper to launch the app
       - type: script
         dest-filename: unofficial-homestuck-collection


### PR DESCRIPTION
Fixes #4 

The flatpak was updated but the version history wasn't because the manifest was cloning the old repo to get the appstream, desktop and icon files. I've updated the repo and rev hash to the latest commit of the new repo. I've also updated the runtimes to the latest version.

You might also want to update all the links to the old repo in the appstream file since iirc github only redirects for 30 days after a repo is migrated.

Since the homepage is also different now, you might also want to change the app id of the package. I'm not entirely sure about the process but I think you just need to make a new PR on flathub/flathub with the new app id and then update this repo to add a file like [this])https://github.com/flathub/org.gnome.iagno/blob/aefd92d1f0b783feedb62d101565e31f9c5dbc4b/flathub.json). This isn't really necessary if you're fine with the redirect though.

After that you can set up verification for the new app id. Here are the docs: https://docs.flathub.org/docs/for-app-authors/verification/

Feel free to ping me if you need any help.